### PR TITLE
Fix Set namespace conflict with Node 4.0.0

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -7,7 +7,7 @@ using namespace Nan;
 ///
 NAN_MODULE_INIT(InitAll) {
     PngImgAdapter::Init();
-    Set(target, New<String>("PngImg").ToLocalChecked(), New<FunctionTemplate>(PngImgAdapter::NewInstance)->GetFunction());
+    Nan::Set(target, New<String>("PngImg").ToLocalChecked(), New<FunctionTemplate>(PngImgAdapter::NewInstance)->GetFunction());
 }
 
 NODE_MODULE(png_img, InitAll)


### PR DESCRIPTION
After update node to 4.0.0 got exception.
Because Set present now in 2 places in Nan and in v8 


 LIBTOOL-STATIC Release/zlib.a
  CXX(target) Release/obj.target/png_img/src/init.o
../src/init.cc:10:5: error: reference to 'Set' is ambiguous
    Set(target, New<String>("PngImg").ToLocalChecked(), New<FunctionTemplate>(PngImgAdapter::NewInstance)->GetFunction());
    ^
/Users/puzankov/.node-gyp/4.0.0/include/node/v8.h:3021:17: note: candidate found by name lookup is 'v8::Set'
class V8_EXPORT Set : public Object {
                ^
../../nan/nan_maybe_43_inl.h:70:24: note: candidate found by name lookup is 'Nan::Set'
NAN_INLINE Maybe<bool> Set(
                       ^
../../nan/nan_maybe_43_inl.h:77:24: note: candidate found by name lookup is 'Nan::Set'
NAN_INLINE Maybe<bool> Set(
                       ^
1 error generated.