### PR TITLE
Support Node.js 14

### DIFF
--- a/src/PngImg.cc
+++ b/src/PngImg.cc
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <memory>
 #include <algorithm>
+#include <stdexcept>
 
 using namespace std;
 


### PR DESCRIPTION
As of now, your cannot build this library with Node.js 14 and it prevents installing `hermione`.

Hermione installs on Node.js 12 though but Node.js 12 will end its life in April, so you have to do something about the build process.

This fix allows the library to be built. All the tests passes. Still it shows plenty of warnings about `unused-result` and `cast-function-type`. It's better to fix them in other pull requests. In my opinion, warnings about unused results and casting are safe to ignore for now.