### PR TITLE
Includes header for std::runtime_error

### DIFF
--- a/src/PngImg.cc
+++ b/src/PngImg.cc
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <memory>
 #include <algorithm>
+#include <stdexcept>
 
 using namespace std;
 


### PR DESCRIPTION
## Why

In node 14.17.3 on PopOS, got compilation error:

```
$ npm i -DE png-img
...
npm ERR! ../src/PngImg.cc: In member function ‘void PngImg::InitStorage_()’:
npm ERR! ../src/PngImg.cc:71:20: error: ‘runtime_error’ is not a member of ‘std’
npm ERR!    71 |         throw std::runtime_error("Image is too large to allocate single buffer");
npm ERR!       |                    ^~~~~~~~~~~~~
npm ERR! make: *** [png_img.target.mk:118: Release/obj.target/png_img/src/PngImg.o] Error 1
```

Looks like stdexcept header file inclusion is missing.

## What

Adds `#include <stdexcept>` and makes png-img to compile.