### PR TITLE
Add missing <limits> include

### DIFF
--- a/src/PngImg.cc
+++ b/src/PngImg.cc
@@ -4,6 +4,7 @@
 #include <png.h>
 #include <string.h>
 #include <memory>
+#include <limits>
 #include <algorithm>
 #include <stdexcept>
 


### PR DESCRIPTION
According to https://en.cppreference.com/w/cpp/types/numeric_limits/max std::numeric_limits is defined in <limits>