### PR TITLE
feat: public interface for utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Create `PngImg` object from passed buffer with image.
 Arguments:
  * `buf` - `Buffer` with image file content.
 ```js
-var fs = require('fs'),
-    PngImg = require('png-img');
+const fs = require('fs');
+const {PngImg} = require('png-img');
 
-var buf = fs.readFileSync('path/to/img.png'),
-    img = new PngImg(buf);
+const buf = fs.readFileSync('path/to/img.png');
+const img = new PngImg(buf);
 ```
 
 ### size()

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "png-img",
   "version": "4.1.0",
   "description": "PNG Image",
-  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./utils": "./dist/utils.js"
+  },
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.7.0"
   },
   "files": [
     "dist",

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -4,7 +4,7 @@ import utils from './utils';
 
 import type {SaveCallback, Size, Color} from './types';
 
-class PngImg {
+export class PngImg {
     private img_: PngImgImpl;
 
     /**
@@ -154,5 +154,3 @@ class PngImg {
         this.img_.write(file, callback);
     }
 }
-
-export = PngImg;

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const testData = require('./data');
 
 describe('constructor', () => {

--- a/test/crop.js
+++ b/test/crop.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const testData = require('./data');
 
 describe('crop', () => {

--- a/test/fill.js
+++ b/test/fill.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const RGBToString = require('../dist/utils').RGBToString;
 const testData = require('./data');
 const rawImg = testData.readFileSync('test32x32.png');

--- a/test/get.js
+++ b/test/get.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const testData = require('./data');
 
 describe('get', () => {

--- a/test/insert.js
+++ b/test/insert.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const testData = require('./data');
 const rawImg = testData.readFileSync('black2x2rgba.png');
 

--- a/test/rotate.js
+++ b/test/rotate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const testData = require('./data');
 const RGBToString = require('../dist/utils').RGBToString;
 

--- a/test/save.js
+++ b/test/save.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const fs = require('fs');
 const path = require('path');
 const testData = require('./data');

--- a/test/set-size.js
+++ b/test/set-size.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const rawImg = require('./data').readFileSync('black2x2rgba.png');
 
 const RED = {r: 255, g: 0, b: 0, a: 0};

--- a/test/set.js
+++ b/test/set.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const RGBToString = require('../dist/utils').RGBToString;
 const testData = require('./data');
 

--- a/test/size.js
+++ b/test/size.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PngImg = require('../dist');
+const {PngImg} = require('../dist');
 const testData = require('./data');
 
 describe('size', () => {


### PR DESCRIPTION
BREAKING_CHANGES:
- drop node support less than 12.7
- PngImg now exports as a default module, but not as a replacement for exports